### PR TITLE
Make path fetching more robust + Spring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ let g:clear_screen_before_test_run = 1
 " The default rspec command is `bundle exec rspec` but can be overwritten with this:
 let g:rspec_command = `custom rspec command`
 
+" Prefer bin/rspec if it is available:
+let g:use_spring = 1
+
 " By default there are no keyboard mappings. Map them like so:
 noremap <Leader>f :RSpecFile<CR>
 noremap <Leader>l :RSpecLine<CR>

--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -39,7 +39,7 @@ function! ClearScreenIfNeeded()
 endfunction
 
 function! TestCommand()
-    if !empty(glob(s:project_root_path . '/bin/rspec'))
+    if g:use_spring && !empty(glob(s:project_root_path . '/bin/rspec'))
         return 'bin/rspec'
     else
         return g:rspec_command

--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -3,48 +3,76 @@ if exists("g:loaded_vttr") || v:version < 700
 endif
 let g:loaded_vttr = 1
 
+"---------------------------------------------------------
+" Config Variables
+"---------------------------------------------------------
 let g:rspec_command = get(g:, 'rspec_command', 'bundle exec rspec')
 let g:clear_screen_before_test_run = get(g:, 'clear_screen_before_test_run', 0)
+let g:use_spring = get(g:, 'use_spring', 0)
+
 "---------------------------------------------------------
 " RSpec Test Runner
 "---------------------------------------------------------
+let s:project_root_path = ''
+let s:spec_path = ''
+let s:use_line = 0
+
 function! ExitScrollMode()
     call system("tmux send-keys -t .+ Escape Escape")
 endfunction
 
-function! ClearScreen()
-    call system("tmux send-keys -t .+ 'clear' Enter")
+function! SetFilePaths()
+    let fullfilename = expand('%:p')
+    let matches = matchlist(fullfilename, '\(.*\)\/\(spec.*\)')
+    if len(matches) < 3
+        return 0
+    endif
+    let s:project_root_path = matches[1]
+    let s:spec_path = matches[2]
+    return 1
 endfunction
 
-function! CurrentProjectRoot()
-  let localfilename = @% " spec/models/drug_spec.rb
-  let fullfilename = expand('%:p') " /users/bpolly/dev/apps/hubservices/spec/models/drug_spec.rb
-  let project_root_path = substitute(fullfilename, localfilename, "", "")
-  return project_root_path
+function! ClearScreenIfNeeded()
+    if g:clear_screen_before_test_run
+        call system("tmux send-keys -t .+ 'clear' Enter")
+    endif
 endfunction
 
-function! TestFilename(use_line)
-    let s:filename = @%
-    if a:use_line == 1
-        let s:filename = s:filename . ":" . line('.')
+function! TestCommand()
+    if !empty(glob(s:project_root_path . '/bin/rspec'))
+        return 'bin/rspec'
+    else
+        return g:rspec_command
     endif
-    if s:filename =~? 'spec/features'
-        let s:filename = s:filename . ' --tag type:feature'
+endfunction
+
+function! TestFilename()
+    let filename = s:spec_path
+    if s:use_line == 1
+        let filename = filename . ":" . line('.')
     endif
-    return s:filename
+    if filename =~? 'spec/features'
+        let filename = filename . ' --tag type:feature'
+    endif
+    return filename
+endfunction
+
+function! SendTestCommand()
+    let system_call = "tmux send-keys -t .+ 'cd " . s:project_root_path . " && " . TestCommand() . " " . TestFilename() . "' Enter"
+    call system(system_call)
 endfunction
 
 function! RspecMe(use_line)
-  let dir = CurrentProjectRoot()
-  let system_call = "tmux send-keys -t .+ 'cd " . dir . " && " . g:rspec_command . " " . TestFilename(a:use_line) . "' Enter"
-  call ExitScrollMode()
-  if g:clear_screen_before_test_run
-      call ClearScreen()
-  endif
-  call system(system_call)
+    let s:use_line = a:use_line
+    if SetFilePaths() == 0 " if the selected file is not valid spec, exit
+        echo 'Error: Could not find spec file'
+        return
+    endif
+    call ExitScrollMode()
+    call ClearScreenIfNeeded()
+    call SendTestCommand()
 endfunction
 
 command! -bar RSpecFile call RspecMe(0)
 command! -bar RSpecLine  call RspecMe(1)
-
 


### PR DESCRIPTION
Fixes a bug encountered where we couldn't infer the project root correctly.

Previously we relied on `@%` to get the project root directory and then inferred the relative spec file location from the full file path with the `@%` path substringed out. However this did not work with vim-ruby due to the `@%` variable returning the full file path when using `:A` to find the alternate spec file.

Now we will use the full file path and regex out the project root and relative spec file paths. This should make it play nicer with more plugins. 

This update also adds support for using Spring when available by checking that the `bin/rspec` binstub is available. If it is, then use `bin/rspec` as the test command, otherwise fall back to the default (currently `bundle exec rspec`).

Finally I cleaned up a lot of the code just to make things more readable.