### PR TITLE
Add option for not changing directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ let g:rspec_command = `custom rspec command`
 " Prefer bin/rspec if it is available:
 let g:use_spring = 1
 
-" CD into the app's base directory:
-let g:vttr_change_directories = 1
+" cd into the app's base directory before running spec:
+let g:vttr_change_directories = 1 
 
 " By default there are no keyboard mappings. Map them like so:
 noremap <Leader>f :RSpecFile<CR>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ let g:rspec_command = `custom rspec command`
 " Prefer bin/rspec if it is available:
 let g:use_spring = 1
 
+" Don't cd into the app's base directory:
+let g:vttr_do_not_change_directories = 1
+
 " By default there are no keyboard mappings. Map them like so:
 noremap <Leader>f :RSpecFile<CR>
 noremap <Leader>l :RSpecLine<CR>

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ let g:rspec_command = `custom rspec command`
 " Prefer bin/rspec if it is available:
 let g:use_spring = 1
 
-" Don't cd into the app's base directory:
-let g:vttr_do_not_change_directories = 1
+" CD into the app's base directory:
+let g:vttr_change_directories = 1
 
 " By default there are no keyboard mappings. Map them like so:
 noremap <Leader>f :RSpecFile<CR>

--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -9,6 +9,7 @@ let g:loaded_vttr = 1
 let g:rspec_command = get(g:, 'rspec_command', 'bundle exec rspec')
 let g:clear_screen_before_test_run = get(g:, 'clear_screen_before_test_run', 0)
 let g:use_spring = get(g:, 'use_spring', 0)
+let g:vttr_do_not_change_directories = get(g:, 'vttr_do_not_change_directors', 0)
 
 "---------------------------------------------------------
 " RSpec Test Runner
@@ -61,7 +62,11 @@ function! TestFilename()
 endfunction
 
 function! SendTestCommand()
-    let system_call = "tmux send-keys -t .+ 'cd " . s:project_root_path . " && " . TestCommand() . " " . TestFilename() . "' Enter"
+    let system_call = "tmux send-keys -t .+ '"
+    if g:vttr_do_not_change_directories == 1
+      let system_call = system_call . "cd " . s:project_root_path . " && "
+    endif
+    let system_call = system_call . TestCommand() . " " . TestFilename() . "' Enter"
     call system(system_call)
 endfunction
 

--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -9,7 +9,7 @@ let g:loaded_vttr = 1
 let g:rspec_command = get(g:, 'rspec_command', 'bundle exec rspec')
 let g:clear_screen_before_test_run = get(g:, 'clear_screen_before_test_run', 0)
 let g:use_spring = get(g:, 'use_spring', 0)
-let g:vttr_do_not_change_directories = get(g:, 'vttr_do_not_change_directors', 0)
+let g:vttr_change_directories = get(g:, 'vttr_change_directories', 0)
 
 "---------------------------------------------------------
 " RSpec Test Runner
@@ -63,7 +63,7 @@ endfunction
 
 function! SendTestCommand()
     let system_call = "tmux send-keys -t .+ '"
-    if g:vttr_do_not_change_directories != 1
+    if g:vttr_change_directories == 1
       let system_call = system_call . "cd " . s:project_root_path . " && "
     endif
     let system_call = system_call . TestCommand() . " " . TestFilename() . "' Enter"

--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -63,7 +63,7 @@ endfunction
 
 function! SendTestCommand()
     let system_call = "tmux send-keys -t .+ '"
-    if g:vttr_do_not_change_directories == 1
+    if g:vttr_do_not_change_directories != 1
       let system_call = system_call . "cd " . s:project_root_path . " && "
     endif
     let system_call = system_call . TestCommand() . " " . TestFilename() . "' Enter"


### PR DESCRIPTION
Since we've been working out of docker lately and Vim runs on my local machine, I've been running into issues where it's trying to `cd` to a directory that doesn't exist in the docker container. This adds a non-default option to skip that step.