### PR TITLE
Fix case where spec is in path more than once

### DIFF
--- a/plugin/vttr.vim
+++ b/plugin/vttr.vim
@@ -24,7 +24,7 @@ endfunction
 
 function! SetFilePaths()
     let fullfilename = expand('%:p')
-    let matches = matchlist(fullfilename, '\(.*\)\/\(spec.*\)')
+    let matches = matchlist(fullfilename, '\(.*\)\/\(spec\/.*\)')
     if len(matches) < 3
         return 0
     endif


### PR DESCRIPTION
```/Users/bpolly/dev/apps/app_name/spec/requests/specialization_test/index_spec.rb```

with the old regex gave match groups:
```
1 ) /Users/bpolly/dev/apps/app_name/spec/requests
2 ) specialization_test/index_spec.rb
```
which if you did not enable switching directories, ran `rspec specialization_test/index_spec.rb` which was a problem if running from project root like I normally do.

New regex:
```
1 ) /Users/bpolly/dev/apps/app_name
2 ) spec/requests/specialization_test/index_spec.rb 

